### PR TITLE
Replace `ember-cli/ext/promise` with `rsvp`

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ module.exports = {
         },
 
         didFail: function(context) {
-          var message = "Deployment of " + this._getHumanDeployMessage(context) + " failed.";
-
           return function(hipchat) {
+            var message = "Deployment of " + this._getHumanDeployMessage(context) + " failed.";
+
             return hipchat.notify(
               message,
               'red'

--- a/lib/hipchat-notifier.js
+++ b/lib/hipchat-notifier.js
@@ -1,4 +1,4 @@
-var Promise    = require('ember-cli/lib/ext/promise');
+var RSVP       = require('rsvp');
 var CoreObject = require('core-object');
 var Hipchatter = require('hipchatter');
 var _          = require('lodash');
@@ -27,7 +27,7 @@ module.exports = CoreObject.extend({
       var room = options.room;
       delete options.room;
 
-      return new Promise(function(resolve, reject) {
+      return new RSVP.Promise(function(resolve, reject) {
         this.hipchat.notify(room, options, function(err) {
           if (err) { return reject(err); }
 

--- a/node-tests/unit/index-test.js
+++ b/node-tests/unit/index-test.js
@@ -2,7 +2,7 @@
 
 var expect          = require('chai').expect;
 var sinon           = require('sinon');
-var Promise         = require('ember-cli/lib/ext/promise');
+var RSVP            = require('rsvp');
 
 // tokens generated with faker
 var AUTH_TOKEN        = 'UBIlRy9Jc2H1igE';
@@ -58,7 +58,7 @@ describe('index', function() {
         name: 'hipchat'
       });
 
-      notifyStub = sandbox.stub().returns(Promise.resolve());
+      notifyStub = sandbox.stub().returns(RSVP.resolve());
 
       context = {
         deployTarget: 'production',

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "ember-cli-deploy-plugin": "^0.2.0",
     "hipchatter": "^0.2.0",
     "lodash": "^4.6.1",
-    "qs": "^5.2.0"
+    "qs": "^5.2.0",
+    "rsvp": "^3.3.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Fixes deprecation warnings from ember-cli 2.12.

Based on https://github.com/ember-cli-deploy/ember-cli-deploy-s3/pull/88

And also fixed a failing test where the text in the `didFail`-hook couldn't be read.